### PR TITLE
fix zone type ontology for France

### DIFF
--- a/resources/boundaries/osm/fr.yaml
+++ b/resources/boundaries/osm/fr.yaml
@@ -3,7 +3,6 @@
         "2": "country"
         "4": "state"
         "6": "state_district"
-        "7": "state_district"
         "8": "city"
         "9": "city_district"
         "10": "suburb"


### PR DESCRIPTION
admin_level 7 are "arrondissements départementaux", which are a sudbivision of admin_level 6 "départements".
They should not be both state_districts.