### PR TITLE
fix belgium osm yaml

### DIFF
--- a/resources/boundaries/osm/be.yaml
+++ b/resources/boundaries/osm/be.yaml
@@ -5,7 +5,7 @@
         "6": "state"
         "7": "state_district"
         "8": "city"
-        "9": "city"
+        "9": "city_district"
 
     overrides:
         id:
@@ -13,9 +13,3 @@
                 # Brussels-Capital Region
                 "54094": "state"
 
-        contained_by:
-            relation:
-                # Antwerpen
-                "59518":
-                    admin_level:
-                        "9": "city_district"


### PR DESCRIPTION
old cities that have been merged should not be set as cities anymore

It improves Cosmogony volumetric tests in Belgium:
* before this PR we had 1715 `city` in Belgium
* with this PR we have 591 `city`
* wikipedia expects 589 :1st_place_medal: 