### PR TITLE
fix spain osm yaml

### DIFF
--- a/resources/boundaries/osm/es.yaml
+++ b/resources/boundaries/osm/es.yaml
@@ -1,10 +1,8 @@
 ---
-  admin_level: 
+  admin_level:
     "2": "country"
     "4": "state"
     "6": "state_district"
-    "7": "state_district"
     "8": "city"
     "9": "city_district"
     "10": "suburb"
-


### PR DESCRIPTION
`state_district` used to mix provinces and comarcas.

This PR improves Cosmogony volumetric tests in Spain:

   - before, we had 249 `state_district`
   - now, we have 47 `state_district`
   - wikipedia expects 50 `provinces` 
