### PR TITLE
Remove boundaries files about French DOMs

### DIFF
--- a/resources/boundaries/osm/gf.yaml
+++ b/resources/boundaries/osm/gf.yaml
@@ -1,6 +1,0 @@
----
-  admin_level: 
-    "6": "country"
-    "7": "state"
-    "8": "city"
-    "10": "suburb"

--- a/resources/boundaries/osm/gp.yaml
+++ b/resources/boundaries/osm/gp.yaml
@@ -1,6 +1,0 @@
----
-  admin_level: 
-    "6": "country"
-    "7": "state"
-    "8": "city"
-    "10": "suburb"

--- a/resources/boundaries/osm/mq.yaml
+++ b/resources/boundaries/osm/mq.yaml
@@ -1,6 +1,0 @@
----
-  admin_level: 
-    "6": "country"
-    "7": "state"
-    "8": "city"
-    "10": "suburb"

--- a/resources/boundaries/osm/re.yaml
+++ b/resources/boundaries/osm/re.yaml
@@ -1,8 +1,0 @@
----
-  admin_level: 
-    "6": "country"
-    "7": "state"
-    "8": "city"
-    "9": "city_district"
-    "10": "suburb"
-

--- a/resources/boundaries/osm/yt.yaml
+++ b/resources/boundaries/osm/yt.yaml
@@ -1,4 +1,0 @@
----
-  admin_level: 
-    "3": "country"
-    "8": "city"


### PR DESCRIPTION
It seems that the usual (FR) administrative hierarchy could be used in DROMs of France [(Département et région d'outre-mer)](https://fr.wikipedia.org/wiki/D%C3%A9partement_et_r%C3%A9gion_d%27outre-mer).  
It would solve potential bugs and confusions, as these regions have their own ISO_3166-2 country code, but are not considered as "countries" in most contexts.

This PR removes specific rules about:
* Guyane Française (GF)
* Guadeloupe (GP)
* Martinique (MQ)
* Réunion (RE)
* Mayotte (YT)