### PR TITLE
Change admin_level associated to city in netherlands

### DIFF
--- a/resources/boundaries/osm/nl.yaml
+++ b/resources/boundaries/osm/nl.yaml
@@ -1,17 +1,7 @@
 ---
-    admin_level: 
+    admin_level:
         "2": "country"
         "3": "country"
         "4": "state"
-        "8": "city"
-        "9": "city_district"
-        "10": "suburb"
+        "10": "city"
         "11": "suburb"
-
-    overrides:
-        id:
-            relation:
-                # Rotterdam, listed as admin_level=10
-                "1411101": "city"
-                # Amsterdam, listed as admin_level=10
-                "271110": "city"


### PR DESCRIPTION
From what we can see the correct admin_level for city is 10 not 8.
Admin_level 8 seems to be Agglomeration: https://en.wikipedia.org/wiki/Utrecht_(agglomeration)
I don't think there is anything that match in cosmogony model.

There is a list of known admin on wikipedia: https://en.wikipedia.org/wiki/List_of_cities,_towns_and_villages_in_the_Netherlands_by_province