### PR TITLE
Belgium: add rule for admin_level=10

### DIFF
--- a/resources/boundaries/osm/be.yaml
+++ b/resources/boundaries/osm/be.yaml
@@ -5,6 +5,7 @@
         "6": "state_district"
         "8": "city"
         "9": "city_district"
+        "10": "suburb"
 
     overrides:
         id:


### PR DESCRIPTION
Import localities with `admin_level=10` in Belgium, such as 
https://www.openstreetmap.org/relation/1392649
or
https://www.openstreetmap.org/relation/2144591
