### PR TITLE
Dutch Centre is calculated with centroid because level-10 has no admin_centres defined.

### DIFF
--- a/resources/boundaries/osm/nl.yaml
+++ b/resources/boundaries/osm/nl.yaml
@@ -1,7 +1,17 @@
 ---
-    admin_level:
+    admin_level: 
         "2": "country"
         "3": "country"
         "4": "state"
-        "10": "city"
+        "8": "city"
+        "9": "city_district"
+        "10": "suburb"
         "11": "suburb"
+
+    overrides:
+        id:
+            relation:
+                # Rotterdam, listed as admin_level=10
+                "1411101": "city"
+                # Amsterdam, listed as admin_level=10
+                "271110": "city"


### PR DESCRIPTION
This reverts commit 41ebec8e5e3e566e2fea6bab0714da9b38c10698.

In commit 41ebec8e5e3e566e2fea6bab0714da9b38c10698, merged through PR #13 the admin level for the Netherlands is set to 10 for "city". This causes very unfortunate and often plain wrong "centers" to be defined. Since nearly no level-10 have an admin_centre but all level-8 do.

I suggest reverting the commit, because that 

The correct levels are explained in the OSM wiki: the Netherlands uses 8 for city (municipality) and 10 for "villages and cities": https://wiki.openstreetmap.org/wiki/Tag:boundary%3Dadministrative#11_admin_level_values_for_specific_countries

Level 8 have a manually set "center" relation, being where the administrative seat of that municipality is located. Level 10 hardly never has this¹

Downside of using level-8 for city is that this excludes a lot of places which are not "official" cities but are used in daily use a lot. As above: no-one would search for "Stichtse Vecht", everyone would search for "Houten" instead.

Downside of using level-10 for city is that many "cities" now appear twice in the dataset: once as municipality (level 8, with correct centre) and once as level 10 (without centre).

The error is apparent in e.g. Haarlem: 
![image](https://user-images.githubusercontent.com/77059/84565540-23623a00-ad6a-11ea-9e72-423cf8d0d32f.png)

Red is the centroid, green is where the actual centre is as defined in admin_level=8. The centroid is used because like nearly all places on admin_level=10, Haarlem has no admin_centre relation.

Both "haarlem" relations can be seen on OSM: 
* Level 10, no admin_centre: https://www.openstreetmap.org/relation/2712154
* level 8, with admin_centre: https://www.openstreetmap.org/relation/2712154

This also causes the same "wrong centre" in Qwant maps: https://www.qwant.com/maps/place/admin:osm:relation:2712154@Haarlem#map=11.86/52.3898421/4.6062086

(Sigh. how hard is it to contain our messy Real World in clean models :D)

---
¹ Large cities such as Amsterdam, Rotterdam, The Hague and Utrecht have, historically, been tagged "wrong" but kept that way, so they often have a manually defined centre on admin_level=10. 